### PR TITLE
Add requests module to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyscard>=2.0.2
+requests


### PR DESCRIPTION
in a fresh venv:
```
python3 get_connective_plugin.py
Traceback (most recent call last):
  File "/home/achille/projects/connective-plugin-linux/get_connective_plugin.py", line 6, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```
