### PR TITLE
bump binVersion

### DIFF
--- a/connective-backend.py
+++ b/connective-backend.py
@@ -731,7 +731,7 @@ def verify_activation_token(token):
 def process_get_info():
     response = {}
     response['version'] = '2.0.2'
-    response['binVersion'] = '2.0.9'
+    response['binVersion'] = '2.0.10'
     return response
 
 


### PR DESCRIPTION
I got an error, telling me to install the, renamed, Nitro SignId plugin. I noticed the Windows plugin was now 2.0.10, and tried bumping the `binVersion`, and it worked, at least for me. I'm not sure if there are any actual changes to the protocol that would need to be implemented.