### PR TITLE
Fix Belgian eID readout failing on readers that report spurious EOF (itsme fix)

### DIFF
--- a/connective-backend.py
+++ b/connective-backend.py
@@ -261,6 +261,7 @@ class BeIdCard(BaseCard):
         # Card data
         self.__serialnr = None
         self.__appletversion = None
+        self._selected_file_id = None
         self.card_data = self.__get_card_data()
 
         if self.card_data:
@@ -351,6 +352,7 @@ class BeIdCard(BaseCard):
         request_data = [ 0x00, 0xA4, 0x08, 0x0C, len(bin_file_id) ] + bin_file_id
         data, sw1, sw2 = self._send_apdu(request_data)
         if sw1 == 0x90 and sw2 == 0x00:
+            self._selected_file_id = file_id
             return True
         else:
             return False
@@ -360,25 +362,41 @@ class BeIdCard(BaseCard):
         '''
         Read the contents of the selected file. select_file() should have been called before.
         '''
+        MAX_READ_RETRIES = 5
         file_contents = []
         offset = 0
         is_eof = False
         while not is_eof:
             request_data = [ 0x00, 0xB0, int(offset / 256), offset % 256, MAX_APDU_READ_LEN ]
             data, sw1, sw2 = self._send_apdu(request_data)
-            if sw1 == 0x90 and sw2 == 0x00:
+            if sw1 == 0x90 and sw2 == 0x00 and len(data) > 0:
                 file_contents.extend(data)
                 offset += len(data)
-            elif (sw1 == 0x6B and sw2 == 0x00) or (sw1 == 0x69 and sw2 == 0x86):
-                # offset beyond eof
-                is_eof = True
+                if len(data) < MAX_APDU_READ_LEN:
+                    is_eof = True
+            elif (sw1 == 0x6B and sw2 == 0x00) or (sw1 == 0x69 and sw2 == 0x86) \
+                    or (sw1 == 0x90 and sw2 == 0x00 and len(data) == 0):
+                recovered = False
+                for _ in range(MAX_READ_RETRIES):
+                    if self._selected_file_id is not None:
+                        self.select_file(self._selected_file_id)
+                    data, sw1, sw2 = self._send_apdu(request_data)
+                    if sw1 == 0x90 and sw2 == 0x00 and len(data) > 0:
+                        file_contents.extend(data)
+                        offset += len(data)
+                        if len(data) < MAX_APDU_READ_LEN:
+                            is_eof = True
+                        recovered = True
+                        break
+                    elif not ((sw1 == 0x6B and sw2 == 0x00) or (sw1 == 0x69 and sw2 == 0x86) \
+                            or (sw1 == 0x90 and sw2 == 0x00 and len(data) == 0)):
+                        break
+                if not recovered:
+                    is_eof = True
             else:
                 # general error
                 is_eof = True
                 file_contents = None
-
-            if len(data) < MAX_APDU_READ_LEN:
-                is_eof = True
         return file_contents
 
 
@@ -787,6 +805,7 @@ def compute_signature(request_reader, request_hash, key_selector):
         signature = None
         if is_authenticated:
             if request_hash and key_selector:
+                card_reader.select_coding_algorithm(key_selector)
                 signature = card_reader.sign(request_hash)
             ignore_result = card_reader.log_off()
 


### PR DESCRIPTION
## Problem

On Linux the itsme / Connective eID flow failed after entering the PIN. The
relying party rejected the readout with `EID_AUTH_FAILED` /
`not_able_to_readout_eid_card`, even though every card command appeared to
succeed. This matches the long-standing report in #36.

Investigation (full APDU trace) turned up two distinct bugs.

## 1. Truncated file reads on readers that report a spurious EOF

`read_selected_file()` treated `6B00` / `6986` (and an empty `9000` response)
as end-of-file. Readers without a keypad (e.g. Alcor AU9560 / AK9563)
intermittently return these **in the middle of a file**: reading the same
1900-byte authentication certificate repeatedly returned 252, 1008 or the full
1900 bytes seemingly at random, and the *identical* `READ BINARY` APDU returned
`6986` on one attempt and 252 bytes of data on the next.

When the certificate was truncated, the relying party could not validate the
card and rejected the whole readout.

A genuine end-of-file is signalled reliably by a final chunk shorter than
`MAX_APDU_READ_LEN`. So an early EOF / empty response while still reading
full-size chunks is now treated as a glitch: the file is re-selected and the
same offset retried (a real EOF keeps returning no data, a glitch returns the
bytes). With this change every multi-chunk file (certificates, photo) reads to
its full, consistent length on every attempt.

## 2. `6985` when signing on a freshly reset card

`compute_signature()` set the security environment, verified the PIN, then ran
PSO:Compute-Digital-Signature. On a freshly reset card the PIN verification
leaves no active security environment, so the card refused to sign with `6985`.
The security environment is now re-set immediately before signing, which is the
canonical eID order and is harmless when one is already active.

## Testing

- Alcor Link AK9563 (keypad-less), Belgian eID, Fedora.
- Reproduced both failures deterministically from the terminal, then confirmed
  the full itsme data-update flow completes successfully end to end.

Fixes #36.